### PR TITLE
Email confirmation added

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,8 +31,8 @@
 class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+  devise :database_authenticatable, :registerable, :recoverable,
+         :rememberable, :trackable, :validatable, :confirmable
   include DeviseTokenAuth::Concerns::User
 
   mount_base64_uploader :image, ImageUploader

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,6 +44,10 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  # Config action mailer with letter opener
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.default_url_options = { host: 'localhost', port: '3000' }
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,10 +33,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
+  # Config action mailer with letter opener
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { host: 'localhost', port: '3000' }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -45,4 +45,6 @@ DeviseTokenAuth.setup do |config|
   # If, however, you wish to integrate with legacy Devise authentication, you can
   # do so by enabling this flag. NOTE: This feature is highly experimental!
   # config.enable_standard_devise_support = false
+
+  config.default_confirm_success_url = 'http://localhost:3000/'
 end

--- a/spec/requests/api/v1/sessions/create_spec.rb
+++ b/spec/requests/api/v1/sessions/create_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+# Test suite for POST /api/v1/auth/sign_in
+describe 'POST /api/v1/auth/sign_in', type: :request do
+  let!(:user) { create(:user) }
+  let(:valid_params) { { email: user.email, password: user.password } }
+
+  context 'when the user is confirmed' do
+    before do
+      user.confirm
+      post '/api/v1/auth/sign_in', params: valid_params
+    end
+
+    it 'returns status code 200' do
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  context 'when the user is not confirmed' do
+    before { post '/api/v1/auth/sign_in', params: valid_params }
+
+    it 'returns status code 401' do
+      expect(response).to have_http_status(401)
+    end
+
+    it 'returns a confirmation error message' do
+      expect(json['errors'][0])
+        .to match("A confirmation email was sent to your account at '#{user.email}'. " \
+          'You must follow the instructions in the email before your account can be activated')
+    end
+  end
+end

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
-# Test suite for POST /auth
-describe 'POST /auth', type: :request do
-  # valid payload
+# Test suite for POST /api/v1/auth
+describe 'POST /api/v1/auth', type: :request do
   let(:valid_params) { attributes_for(:user) }
   let(:invalid_params) { attributes_for(:user, password: '1234') }
 


### PR DESCRIPTION
Email confirmation added with Devise Token Auth gem.
Action mailer configured for development and test environments.
Default confirm success URL configured in Devise Token Auth initializer.
Sign in tests implemented for a confirmed and unconfirmed user.
Sign up request test route description fixed.