### PR TITLE
Limit number of targets per user

### DIFF
--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -19,9 +19,21 @@
 #
 
 class Target < ApplicationRecord
+  MAXIMUM_NUMBER_OF_TARGETS_PER_USER = 10
+
   belongs_to :topic
   belongs_to :user
 
   validates :title, presence: true, uniqueness: true
   validates :latitude, :longitude, presence: true
+
+  validate :target_limit_per_user
+
+  private
+
+  def target_limit_per_user
+    if user.targets.size >= MAXIMUM_NUMBER_OF_TARGETS_PER_USER
+      errors.add(:user, I18n.t('api.targets.create.limit_reached'))
+    end
+  end
 end

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -33,7 +33,7 @@ class Target < ApplicationRecord
 
   def target_limit_per_user
     if user.targets.size >= MAXIMUM_NUMBER_OF_TARGETS_PER_USER
-      errors.add(:user, I18n.t('api.targets.create.limit_reached'))
+      errors.add(:user, "#{I18n.t('api.targets.create.limit_reached')} (#{MAXIMUM_NUMBER_OF_TARGETS_PER_USER})")
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,3 +38,6 @@ en:
       facebook:
         forbidden: 'Not authorized'
         already_registerd: 'User already registered with email/password'
+    targets:
+      create:
+        limit_reached: 'maximum number of targets reached'

--- a/spec/requests/api/v1/targets/create_spec.rb
+++ b/spec/requests/api/v1/targets/create_spec.rb
@@ -53,7 +53,7 @@ describe 'POST /api/v1/targets', type: :request do
 
     it 'returns a validation failure message' do
       expect(json['message'])
-        .to match("Validation failed: User #{I18n.t('api.targets.create.limit_reached')}")
+        .to match("Validation failed: User #{I18n.t('api.targets.create.limit_reached')} (#{Target::MAXIMUM_NUMBER_OF_TARGETS_PER_USER})")
     end
   end
 end

--- a/spec/requests/api/v1/targets/create_spec.rb
+++ b/spec/requests/api/v1/targets/create_spec.rb
@@ -40,4 +40,20 @@ describe 'POST /api/v1/targets', type: :request do
         .to match('Validation failed: Topic must exist')
     end
   end
+
+  context 'when the user already has 10 targets created' do
+    before do
+      create_list(:target, 10, user_id: user.id)
+      post '/api/v1/targets', params: payload, headers: auth_headers(user)
+    end
+
+    it 'returns status code 422' do
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'returns a validation failure message' do
+      expect(json['message'])
+        .to match("Validation failed: User #{I18n.t('api.targets.create.limit_reached')}")
+    end
+  end
 end


### PR DESCRIPTION
## TASKS DONE

- [X] Add custom validation in target model to limit number of targets per user to 10.
- [X] Add error message in locales tree to display when the limit is reached.
- [X] Update request test for create target route to contemplate this new limit
